### PR TITLE
Fix "committer identity unknown" on merge

### DIFF
--- a/src/qram/git.py
+++ b/src/qram/git.py
@@ -83,7 +83,13 @@ class Git:
               committer_name: str, committer_email: str) -> None:
         # FIXME: needs rollback if something fails
         # plain `git merge` does not allow specifying author, so use --no-commit + `git commit`
-        check_call(self.repo, ['merge', what, '--no-ff', '--no-commit'])
+        check_call(self.repo, [
+            '-c', f'user.name={committer_name}',
+            '-c', f'user.email={committer_email}',
+            'merge', what,
+            '--no-ff',
+            '--no-commit',
+        ])
         check_call(self.repo, [
             '-c', f'user.name={committer_name}',
             '-c', f'user.email={committer_email}',


### PR DESCRIPTION
Despite `--no-commit`, merge would still argue about `please tell me who you are`, if you do not have username configured globally.